### PR TITLE
Support sudo and EC2 Image Builder

### DIFF
--- a/amazon_ssm_agent.fc
+++ b/amazon_ssm_agent.fc
@@ -2,7 +2,7 @@
 
 /usr/bin/ssm-session-worker             --      gen_context(system_u:object_r:amazon_ssm_agent_exec_t,s0)
 
-/usr/lib/systemd/system/amazon-ssm-agent.service                --      gen_context(system_u:object_r:amazon_ssm_agent_unit_file_t,s0)
+/etc/systemd/system/amazon-ssm-agent.service                --      gen_context(system_u:object_r:amazon_ssm_agent_unit_file_t,s0)
 
 /var/lib/amazon/ssm(/.*)?               gen_context(system_u:object_r:amazon_ssm_agent_var_lib_t,s0)
 

--- a/amazon_ssm_agent.sh
+++ b/amazon_ssm_agent.sh
@@ -54,8 +54,8 @@ sepolicy manpage -p . -d amazon_ssm_agent_t
 /sbin/restorecon -R -v /var/lib/amazon/ssm/ipc/termination
 # Fixing the file context on /usr/bin/ssm-session-worker
 /sbin/restorecon -R -v /usr/bin/ssm-session-worker
-# Fixing the file context on /usr/lib/systemd/system/amazon-ssm-agent.service
-/sbin/restorecon -F -R -v /usr/lib/systemd/system/amazon-ssm-agent.service
+# Fixing the file context on /etc/systemd/system/amazon-ssm-agent.service
+/sbin/restorecon -F -R -v /etc/systemd/system/amazon-ssm-agent.service
 # # Generate a rpm package for the newly generated policy
 
 pwd=$(pwd)

--- a/amazon_ssm_agent.te
+++ b/amazon_ssm_agent.te
@@ -46,6 +46,7 @@ optional {
         type systemd_unit_file_t;
         type passwd_exec_t;
         type rpm_var_lib_t;
+        type chkpwd_exec_t;
         class netlink_audit_socket { read write create nlmsg_relay };
         class netlink_route_socket { bind create getattr nlmsg_read read write };
         class udp_socket { connect create getattr getopt setopt read write sendto };
@@ -81,7 +82,7 @@ optional {
         allow amazon_ssm_agent_t system_dbusd_t:file { open read };
         allow amazon_ssm_agent_t bin_t:dir relabelto;
         allow amazon_ssm_agent_t bin_t:lnk_file { relabelfrom relabelto };
-        allow amazon_ssm_agent_t etc_t:file { relabelto rename setattr };
+        allow amazon_ssm_agent_t etc_t:file { relabelto rename setattr write};
         allow amazon_ssm_agent_t etc_t:lnk_file { relabelfrom relabelto };
         allow amazon_ssm_agent_t syslog_conf_t:file relabelfrom;
         allow amazon_ssm_agent_t systemd_unit_file_t:dir { add_name remove_name write };
@@ -106,7 +107,10 @@ optional {
         allow amazon_ssm_agent_t rpm_var_lib_t:dir create;
         allow amazon_ssm_agent_t amazon_ssm_agent_unit_file_t:service stop;
         allow amazon_ssm_agent_t boot_t:file { create relabelfrom };
+        allow amazon_ssm_agent_t chkpwd_exec_t:file execute_no_trans;
 }
+
+auth_exec_chkpwd(amazon_ssm_agent_t)
 
 manage_dirs_pattern(amazon_ssm_agent_t, amazon_ssm_agent_log_t, amazon_ssm_agent_log_t)
 manage_files_pattern(amazon_ssm_agent_t, amazon_ssm_agent_log_t, amazon_ssm_agent_log_t)

--- a/amazon_ssm_agent_selinux.spec
+++ b/amazon_ssm_agent_selinux.spec
@@ -3,7 +3,7 @@
 
 %define relabel_files() \
 restorecon -R /usr/bin/amazon-ssm-agent; \
-restorecon -R /usr/lib/systemd/system/amazon-ssm-agent.service; \
+restorecon -R /etc/systemd/system/amazon-ssm-agent.service; \
 restorecon -R /var/lib/amazon/ssm; \
 restorecon -R /var/log/amazon/ssm; \
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

Happy contributing!

-->

## Motivation

In order to confine ssm agent in an golden image, EC2 image builder is used to generate AMI images. During testing image, sudo permission is required. If you attempt to run `sudo` in SSM session manager, you will see the following error:
```sudo: PAM account management error: Authentication service cannot retrieve authentication info```

## Proposed Changes
Include `sudo` in the SEpolicy
(Write out the details of your proposed changes here.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)
Run `sudo whoami` in SSM session manager.

