### PR TITLE
Support sudo and EC2 Image Builder

### DIFF
--- a/amazon_ssm_agent.fc
+++ b/amazon_ssm_agent.fc
@@ -2,7 +2,7 @@
 
 /usr/bin/ssm-session-worker             --      gen_context(system_u:object_r:amazon_ssm_agent_exec_t,s0)
 
-/usr/lib/systemd/system/amazon-ssm-agent.service                --      gen_context(system_u:object_r:amazon_ssm_agent_unit_file_t,s0)
+/etc/systemd/system/amazon-ssm-agent.service                --      gen_context(system_u:object_r:amazon_ssm_agent_unit_file_t,s0)
 
 /var/lib/amazon/ssm(/.*)?               gen_context(system_u:object_r:amazon_ssm_agent_var_lib_t,s0)
 

--- a/amazon_ssm_agent.sh
+++ b/amazon_ssm_agent.sh
@@ -54,8 +54,8 @@ sepolicy manpage -p . -d amazon_ssm_agent_t
 /sbin/restorecon -R -v /var/lib/amazon/ssm/ipc/termination
 # Fixing the file context on /usr/bin/ssm-session-worker
 /sbin/restorecon -R -v /usr/bin/ssm-session-worker
-# Fixing the file context on /usr/lib/systemd/system/amazon-ssm-agent.service
-/sbin/restorecon -F -R -v /usr/lib/systemd/system/amazon-ssm-agent.service
+# Fixing the file context on /etc/systemd/system/amazon-ssm-agent.service
+/sbin/restorecon -F -R -v /etc/systemd/system/amazon-ssm-agent.service
 # # Generate a rpm package for the newly generated policy
 
 pwd=$(pwd)

--- a/amazon_ssm_agent.te
+++ b/amazon_ssm_agent.te
@@ -47,6 +47,18 @@ optional {
         type passwd_exec_t;
         type rpm_var_lib_t;
         type chkpwd_exec_t;
+        type unconfined_t;
+        type cloud_init_exec_t;
+        type user_cron_spool_t;
+        type system_cronjob_t;
+        type crontab_exec_t;
+        type policykit_t;
+        type irqbalance_t;
+        type tuned_t;
+        type tmp_t;
+        type dhcpc_t;
+        type systemd_hostnamed_t;
+        type init_var_run_t;
         class netlink_audit_socket { read write create nlmsg_relay };
         class netlink_route_socket { bind create getattr nlmsg_read read write };
         class udp_socket { connect create getattr getopt setopt read write sendto };
@@ -57,7 +69,7 @@ optional {
         class sock_file { create unlink write getattr};
         class dir { getattr search relabelfrom relabelto remove_name add_name create write read };
         class process { setexec execmem setrlimit setpgid setfscreate setsched };
-        class capability { linux_immutable net_admin audit_write setfcap dac_override dac_read_search sys_ptrace chown fowner fsetid net_admin kill setgid setuid };
+        class capability { linux_immutable net_admin audit_write setfcap dac_override dac_read_search sys_ptrace chown fowner fsetid net_admin kill setgid setuid sys_resource };
         class service { start status stop };
         class passwd passwd;
         class netlink_selinux_socket { bind create };
@@ -77,7 +89,7 @@ optional {
         allow amazon_ssm_agent_t var_run_t:file { create unlink };
         allow amazon_ssm_agent_t rpm_exec_t:file relabelto;
         allow amazon_ssm_agent_t self:process { setexec execmem setrlimit setpgid setfscreate setsched };
-        allow amazon_ssm_agent_t self:capability { linux_immutable net_admin audit_write setfcap dac_override dac_read_search sys_ptrace chown fowner fsetid net_admin kill setgid setuid };
+        allow amazon_ssm_agent_t self:capability { linux_immutable net_admin audit_write setfcap dac_override dac_read_search sys_ptrace chown fowner fsetid net_admin kill setgid setuid sys_resource };
         allow amazon_ssm_agent_t system_dbusd_t:dir { getattr search };
         allow amazon_ssm_agent_t system_dbusd_t:file { open read };
         allow amazon_ssm_agent_t bin_t:dir relabelto;
@@ -108,6 +120,24 @@ optional {
         allow amazon_ssm_agent_t amazon_ssm_agent_unit_file_t:service stop;
         allow amazon_ssm_agent_t boot_t:file { create relabelfrom };
         allow amazon_ssm_agent_t chkpwd_exec_t:file execute_no_trans;
+        allow amazon_ssm_agent_t cloud_init_exec_t:file { execute execute_no_trans };
+        allow amazon_ssm_agent_t init_var_run_t:file { read open getattr };
+        allow amazon_ssm_agent_t dhcpc_t:dir { getattr search };
+        allow amazon_ssm_agent_t dhcpc_t:file { open read };
+        allow amazon_ssm_agent_t irqbalance_t:dir { getattr search };
+        allow amazon_ssm_agent_t irqbalance_t:file { open read };
+        allow amazon_ssm_agent_t policykit_t:dir { getattr search };
+        allow amazon_ssm_agent_t policykit_t:file { open read };
+        allow amazon_ssm_agent_t system_cronjob_t:dir getattr;
+        allow amazon_ssm_agent_t user_cron_spool_t:dir { search getattr write add_name setattr rename remove_name };
+        allow amazon_ssm_agent_t user_cron_spool_t:file { create open rename setattr };
+        allow amazon_ssm_agent_t crontab_exec_t:file { execute execute_no_trans };
+        allow amazon_ssm_agent_t systemd_hostnamed_t:dir getattr;
+        allow amazon_ssm_agent_t tmp_t:file { execute execute_no_trans };
+        allow amazon_ssm_agent_t tuned_t:dir { getattr search };
+        allow amazon_ssm_agent_t tuned_t:file { open read };
+        allow amazon_ssm_agent_t unconfined_t:dir { getattr search };
+        allow amazon_ssm_agent_t unconfined_t:file { open read };
 }
 
 auth_exec_chkpwd(amazon_ssm_agent_t)
@@ -311,6 +341,10 @@ files_manage_etc_dirs(amazon_ssm_agent_t)
 systemd_create_unit_file_lnk(amazon_ssm_agent_t)
 
 files_manage_etc_dirs(amazon_ssm_agent_t)
+
+miscfiles_manage_generic_cert_dirs(amazon_ssm_agent_t)
+cloudform_read_lib_files(amazon_ssm_agent_t)
+cloudform_read_lib_lnk_files(amazon_ssm_agent_t)
 
 optional {
         gen_require(`

--- a/amazon_ssm_agent.te
+++ b/amazon_ssm_agent.te
@@ -46,6 +46,7 @@ optional {
         type systemd_unit_file_t;
         type passwd_exec_t;
         type rpm_var_lib_t;
+        type chkpwd_exec_t;
         class netlink_audit_socket { read write create nlmsg_relay };
         class netlink_route_socket { bind create getattr nlmsg_read read write };
         class udp_socket { connect create getattr getopt setopt read write sendto };
@@ -81,7 +82,7 @@ optional {
         allow amazon_ssm_agent_t system_dbusd_t:file { open read };
         allow amazon_ssm_agent_t bin_t:dir relabelto;
         allow amazon_ssm_agent_t bin_t:lnk_file { relabelfrom relabelto };
-        allow amazon_ssm_agent_t etc_t:file { relabelto rename setattr };
+        allow amazon_ssm_agent_t etc_t:file { relabelto rename setattr write};
         allow amazon_ssm_agent_t etc_t:lnk_file { relabelfrom relabelto };
         allow amazon_ssm_agent_t syslog_conf_t:file relabelfrom;
         allow amazon_ssm_agent_t systemd_unit_file_t:dir { add_name remove_name write };
@@ -106,7 +107,10 @@ optional {
         allow amazon_ssm_agent_t rpm_var_lib_t:dir create;
         allow amazon_ssm_agent_t amazon_ssm_agent_unit_file_t:service stop;
         allow amazon_ssm_agent_t boot_t:file { create relabelfrom };
+        allow amazon_ssm_agent_t chkpwd_exec_t:file execute_no_trans;
 }
+
+auth_exec_chkpwd(amazon_ssm_agent_t)
 
 manage_dirs_pattern(amazon_ssm_agent_t, amazon_ssm_agent_log_t, amazon_ssm_agent_log_t)
 manage_files_pattern(amazon_ssm_agent_t, amazon_ssm_agent_log_t, amazon_ssm_agent_log_t)

--- a/amazon_ssm_agent_selinux.spec
+++ b/amazon_ssm_agent_selinux.spec
@@ -3,7 +3,7 @@
 
 %define relabel_files() \
 restorecon -R /usr/bin/amazon-ssm-agent; \
-restorecon -R /usr/lib/systemd/system/amazon-ssm-agent.service; \
+restorecon -R /etc/systemd/system/amazon-ssm-agent.service; \
 restorecon -R /var/lib/amazon/ssm; \
 restorecon -R /var/log/amazon/ssm; \
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

Happy contributing!

-->

## Motivation

1. It is very often to create security hardened image using EC2 image builder that confine ssm agent. During test component of image built, the test script and cleanup script cannot be run because `/tmp` is the (default) working directory.
    ```
    Waiting for Cloud-init to initialize ...
    Cloud-init fails to initialize ... waiting another 5 minutes for the instance to stabilize
    /var/lib/amazon/ssm/i-0ffa6082624772230/document/orchestration/70fee8e7-c4c9-4dbc-ad2d-872e55a47e96/awsrunShellScript/0.awsrunShellScript/_script.sh: /tmp/imagebuilder/TaskOrchestratorAndExecutor/bootstrap.sh: /usr/bin/env: bad interpreter: Permission denied
    {"failureMessage":"Unable to bootstrap TOE"}
    ```
    Some other permissions are needed during cleanup.
    ```
    bash: /usr/bin/crontab: Permission denied\nbash: /usr/bin/crontab: Permission denied\n",
    ```

2. Want to grant `sudo` permission for SSM session manager. If you attempt to run sudo in SSM session manager, you will see the following error:
`sudo: PAM account management error: Authentication service cannot retrieve authentication info`
In some occasions where the ssm session manager is first ever run, ssm agent also create `ssm-user` in Linux.

3. The patch script shows error due to incorrect path of `amazon-ssm-agent.service`.
    ```
    + /sbin/restorecon -F -R -v /usr/lib/systemd/system/amazon-ssm-agent.service
    /sbin/restorecon:  lstat(/usr/lib/systemd/system/amazon-ssm-agent.service) failed:  No such file or directory
    ```

## Proposed Changes

1. Include minimum policy required to pass the EC2 image builder.
2. Allow sudo and some necessary permissions for Session Manager to work.
3. Fix the path of `amazon-ssm-agent.service`.

## Test Plan
1. Create a EC2 image builder pipeline to create an image that confine ssm agent according to the instructions.
2. Ensure no error messages during the instructions run. (i.e.  not seeing errors like `No such file or directory`)
3. Add (amazon provided) `reboot-test-linux` as test component.
4. See if the image pipeline can pass the reboot test and generate the AMI.
5. Launch an EC2 instance using the generated AMI. Connect the EC2 using SSM Session Manager.
6. Run `sudo whoami`.

Note: This commit just give minimal permissions required and does not guaranteed to work with other custom developed build and test components in EC2 image builder.

